### PR TITLE
Fix TypeError: Provided value cannot be bound to SQLite parameter 4

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -200,7 +200,13 @@ const indexFile = async({
 					?
 				)
 			`);
-			stmt.run(mesId, idx, swipe, mes.swipe_info?.[idx]?.send_date ?? mes.send_date);
+			stmt.run(
+    mesId,
+    idx,
+    swipe,
+    (mes.swipe_info?.[idx]?.send_date ?? mes.send_date ?? null)
+);
+
 		}
 	}
 };


### PR DESCRIPTION
Ran into this error

```
file:///C:/Users/Nissa/nissa-dev/SillyTavern/plugins/SillyTavern-ChatSearchPlugin/index.mjs:203
                        stmt.run(mesId, idx, swipe, mes.swipe_info?.[idx]?.send_date ?? mes.send_date);
                             ^

TypeError: Provided value cannot be bound to SQLite parameter 4.
    at indexFile (file:///C:/Users/Nissa/nissa-dev/SillyTavern/plugins/SillyTavern-ChatSearchPlugin/index.mjs:203:9)
    at indexFiles (file:///C:/Users/Nissa/nissa-dev/SillyTavern/plugins/SillyTavern-ChatSearchPlugin/index.mjs:280:6)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async initIndex (file:///C:/Users/Nissa/nissa-dev/SillyTavern/plugins/SillyTavern-ChatSearchPlugin/index.mjs:443:3)
    at async init (file:///C:/Users/Nissa/nissa-dev/SillyTavern/plugins/SillyTavern-ChatSearchPlugin/index.mjs:516:2)
    at async initPlugin (file:///C:/Users/Nissa/nissa-dev/SillyTavern/src/plugin-loader.js:201:5)
    at async loadFromFile (file:///C:/Users/Nissa/nissa-dev/SillyTavern/src/plugin-loader.js:140:16)
    at async loadFromDirectory (file:///C:/Users/Nissa/nissa-dev/SillyTavern/src/plugin-loader.js:99:17)
    at async loadPlugins (file:///C:/Users/Nissa/nissa-dev/SillyTavern/src/plugin-loader.js:61:13)
    at async initializePlugins (file:///C:/Users/Nissa/nissa-dev/SillyTavern/server.js:875:32) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

Sharing quick fix in case helpful